### PR TITLE
Fix compiling with `-Werror=format-security`.

### DIFF
--- a/src/modules/Manual/ManualWidget.cpp
+++ b/src/modules/Manual/ManualWidget.cpp
@@ -20,8 +20,8 @@ void ManualWidget::step() {
 		}
 		if (manualText && manualText != lastManualText && !manualText->manualTitle.empty()) {
 			lastManualText = manualText;
-			DEBUG(manualText->manualTitle.c_str());
-			DEBUG(manualText->manualContent.c_str());
+			DEBUG("%s", manualText->manualTitle.c_str());
+			DEBUG("%s", manualText->manualContent.c_str());
 		}
 	}
 	ModuleWidgetWithScrews::step();

--- a/src/test/Asserts.cpp
+++ b/src/test/Asserts.cpp
@@ -3,7 +3,7 @@
 
 bool assertEquals(int value1, int value2, const char* message) {
 	if (value1 != value2) {
-		DEBUG(message);
+		DEBUG("%s", message);
 		DEBUG("value1: %d", value1);
 		DEBUG("value2: %d", value2);
 		return false;


### PR DESCRIPTION
When compiling with `-Werror=format-security` (default on Arch Linux, for example), gcc tries to strictly resolve format arguments to printf functions, which may require giving hints to the compiler where to find these format arguments. The easy fix here is to always provide a static format argument.

### Reproduce the error
```
CXXFLAGS="-Wformat -Werror=format-security" make
```
<pre>In file included from <b>/usr/include/vcvrack/common.hpp:269</b>,
                 from <b>/usr/include/vcvrack/rack.hpp:22</b>,
                 from <b>src/test/../Ahornberg.hpp:5</b>,
                 from <b>src/test/Asserts.cpp:2</b>:
<b>src/test/Asserts.cpp:</b> In function ‘<b>bool assertEquals(int, int, const char*)</b>’:
<b>/usr/include/vcvrack/logger.hpp:13:45:</b> <font color="#C01C28"><b>error: </b></font>format not a string literal and no format arguments [<font color="#C01C28"><b>-Werror=format-security</b></font>]
   13 | #define DEBUG(format, ...) <font color="#C01C28"><b>rack::logger::log(rack::logger::DEBUG_LEVEL, __FILE__, __LINE__, __FUNCTION__, format, ##__VA_ARGS__)</b></font>
      |                            <font color="#C01C28"><b>~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~</b></font>
<b>src/test/Asserts.cpp:6:17:</b> <font color="#2AA1B3"><b>note: </b></font>in expansion of macro ‘<b>DEBUG</b>’
    6 |                 <font color="#2AA1B3"><b>DEBUG</b></font>(message);
      |                 <font color="#2AA1B3"><b>^~~~~</b></font>
</pre>

### Reference
- https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wformat-security

### Alternative
An alternative solution would be to add something like `__attribute__ ((format (printf, x, y)))` to your own functions.